### PR TITLE
#26 support more requests

### DIFF
--- a/src/test/java/com/amihaiemil/zold/mock/AssertRequest.java
+++ b/src/test/java/com/amihaiemil/zold/mock/AssertRequest.java
@@ -25,31 +25,18 @@
  */
 package com.amihaiemil.zold.mock;
 
-import java.io.IOException;
+import org.apache.http.HttpResponse;
+
 import java.util.Arrays;
 import java.util.Collection;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.params.HttpParams;
-import org.apache.http.protocol.HttpContext;
-import org.junit.Assert;
 
 /**
- * Asserts that a {@link HttpRequest} meets certain conditions specified by the
- * user. If successful, a response predetermined by the user is returned,
- * otherwise it {@link Assert#fail() fails}.
- *
- * @author George Aristy (george.aristy@gmail.com)
+ * Assert for an HttpRequest under test.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 0.0.1
+ * @since 0.0.2
  */
-public final class AssertRequest implements HttpClient {
+public final class AssertRequest {
     /**
      * The response to return if all conditions are met.
      */
@@ -61,99 +48,27 @@ public final class AssertRequest implements HttpClient {
 
     /**
      * Ctor.
-     *
-     * @param response The response that should be returned if all conditions
-     * are met.
-     * @param conditions The conditions that the http request must satisfy.
+     * @param resp Given response.
+     * @param conds Given conditions.
      */
-    @SuppressWarnings("unchecked")
-    public AssertRequest(final HttpResponse response,
-        final Condition... conditions) {
-        this.response = response;
-        this.conditions = Arrays.asList(conditions);
-    }
-
-    @Override
-    public HttpParams getParams() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    public ClientConnectionManager getConnectionManager() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    public HttpResponse execute(final HttpUriRequest request)
-        throws IOException, ClientProtocolException {
-        this.check(request);
-        return this.response;
-    }
-
-    @Override
-    public HttpResponse execute(final HttpUriRequest request,
-        final HttpContext context)
-        throws IOException, ClientProtocolException {
-        this.check(request);
-        return this.response;
-    }
-
-    @Override
-    public HttpResponse execute(final HttpHost target,
-        final HttpRequest request)
-        throws IOException, ClientProtocolException {
-        this.check(request);
-        return this.response;
-    }
-
-    @Override
-    public HttpResponse execute(final HttpHost target,
-        final HttpRequest request, final HttpContext context)
-        throws IOException, ClientProtocolException {
-        this.check(request);
-        return this.response;
-    }
-
-    @Override
-    public <T> T execute(final HttpUriRequest request,
-        final ResponseHandler<? extends T> responseHandler)
-        throws IOException, ClientProtocolException {
-        this.check(request);
-        return responseHandler.handleResponse(this.response);
-    }
-
-    @Override
-    public <T> T execute(final HttpUriRequest request,
-        final ResponseHandler<? extends T> responseHandler,
-        final HttpContext context)
-        throws IOException, ClientProtocolException {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    public <T> T execute(final HttpHost target, final HttpRequest request,
-        final ResponseHandler<? extends T> responseHandler)
-        throws IOException, ClientProtocolException {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    //@checkstyle ParameterNumber (8 lines)
-    @Override
-    public <T> T execute(final HttpHost target, final HttpRequest request,
-        final ResponseHandler<? extends T> responseHandler,
-        final HttpContext context)
-        throws IOException, ClientProtocolException {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public AssertRequest(final HttpResponse resp, final Condition... conds) {
+        this.response = resp;
+        this.conditions = Arrays.asList(conds);
     }
 
     /**
-     * Checks all conditions against the request.
-     *
-     * @param request The request.
+     * Return the response.
+     * @return HttpResponse.
      */
-    private void check(final HttpRequest request) {
-        this.conditions.forEach(cond -> {
-            cond.test(request);
-        });
+    public HttpResponse response() {
+        return this.response;
+    }
+
+    /**
+     * Return the conditions.
+     * @return Collection of Condition.
+     */
+    public Collection<Condition> conditions() {
+        return this.conditions;
     }
 }

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
@@ -146,7 +146,8 @@ public final class MockHttpClient implements HttpClient {
      * @return HttpResponse if all the cehcks pass.
      */
     private HttpResponse check(final HttpRequest request) {
-        final Collection<Condition> conditions = this.assertions.get(0).conditions();
+        final Collection<Condition> conditions = this.assertions.get(0)
+            .conditions();
         conditions.forEach(cond -> {
             cond.test(request);
         });

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
@@ -26,6 +26,7 @@
 package com.amihaiemil.zold.mock;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -57,7 +58,7 @@ public final class MockHttpClient implements HttpClient {
     /**
      * Assertions.
      */
-    private final List<AssertRequest> assertions;
+    private final List<AssertRequest> assertions = new ArrayList<>();
 
     /**
      * Ctor.
@@ -66,7 +67,9 @@ public final class MockHttpClient implements HttpClient {
      */
     @SuppressWarnings("unchecked")
     public MockHttpClient(final AssertRequest... assertions) {
-        this.assertions = Arrays.asList(assertions);
+        Arrays.stream(assertions).forEach((assertion) -> {
+            this.assertions.add(assertion);
+        });
     }
 
     @Override
@@ -152,7 +155,7 @@ public final class MockHttpClient implements HttpClient {
             cond.test(request);
         });
         final HttpResponse response = this.assertions.get(0).response();
-        this.assertions.remove(response);
+        this.assertions.remove(0);
         return response;
     }
 }

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
@@ -58,7 +58,7 @@ public final class MockHttpClient implements HttpClient {
     /**
      * Assertions.
      */
-    private final List<AssertRequest> assertions = new ArrayList<>();
+    private final List<AssertRequest> assertions;
 
     /**
      * Ctor.
@@ -67,6 +67,7 @@ public final class MockHttpClient implements HttpClient {
      */
     @SuppressWarnings("unchecked")
     public MockHttpClient(final AssertRequest... assertions) {
+        this.assertions = new ArrayList<>();
         Arrays.stream(assertions).forEach((assertion) -> {
             this.assertions.add(assertion);
         });

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClient.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of zold-java-client nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.zold.mock;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Assert;
+
+/**
+ * An HttpClient which asserts that some {@link HttpRequest}s
+ * meet certain conditions specified by the user.
+ * If successful, a response predetermined by the user is returned
+ * for each request, otherwise it {@link Assert#fail() fails}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @version $Id$
+ * @since 0.0.1
+ */
+public final class MockHttpClient implements HttpClient {
+
+    /**
+     * Assertions.
+     */
+    private final List<AssertRequest> assertions;
+
+    /**
+     * Ctor.
+     *
+     * @param assertions Given assertions.
+     */
+    @SuppressWarnings("unchecked")
+    public MockHttpClient(final AssertRequest... assertions) {
+        this.assertions = Arrays.asList(assertions);
+    }
+
+    @Override
+    public HttpParams getParams() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public HttpResponse execute(final HttpUriRequest request)
+        throws IOException, ClientProtocolException {
+        return this.check(request);
+    }
+
+    @Override
+    public HttpResponse execute(final HttpUriRequest request,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        return this.check(request);
+    }
+
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request)
+        throws IOException, ClientProtocolException {
+        return this.check(request);
+    }
+
+    @Override
+    public HttpResponse execute(final HttpHost target,
+        final HttpRequest request, final HttpContext context)
+        throws IOException, ClientProtocolException {
+        return this.check(request);
+    }
+
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        return responseHandler.handleResponse(
+            this.check(request)
+        );
+    }
+
+    @Override
+    public <T> T execute(final HttpUriRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    //@checkstyle ParameterNumber (8 lines)
+    @Override
+    public <T> T execute(final HttpHost target, final HttpRequest request,
+        final ResponseHandler<? extends T> responseHandler,
+        final HttpContext context)
+        throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /**
+     * Checks all conditions against the request.
+     *
+     * @param request The request.
+     * @return HttpResponse if all the cehcks pass.
+     */
+    private HttpResponse check(final HttpRequest request) {
+        final Collection<Condition> conditions = this.assertions.get(0).conditions();
+        conditions.forEach(cond -> {
+            cond.test(request);
+        });
+        final HttpResponse response = this.assertions.get(0).response();
+        this.assertions.remove(response);
+        return response;
+    }
+}

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClientTestCase.java
@@ -36,13 +36,13 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Tests for {@link AssertRequest}.
+ * Tests for {@link MockHttpClient}.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
  */
-public final class AssertRequestTestCase {
+public final class MockHttpClientTestCase {
     /**
      * Should return the given response if the request meets the given
      * condition.
@@ -57,12 +57,14 @@ public final class AssertRequestTestCase {
             )
         );
         MatcherAssert.assertThat(
-            new AssertRequest(
-                response,
-                new Condition(
-                    "",
-                    // @checkstyle LineLength (1 line)
-                    r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+            new MockHttpClient(
+                new AssertRequest(
+                    response,
+                    new Condition(
+                        "",
+                        // @checkstyle LineLength (1 line)
+                        r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+                    )
                 )
             ).execute(new HttpGet("http://some.test.com")),
             Matchers.is(response)
@@ -76,11 +78,13 @@ public final class AssertRequestTestCase {
      */
     @Test(expected = AssertionError.class)
     public void failIfRequestDoesNotMeetCondition() throws Exception {
-        new AssertRequest(
-            null,
-            new Condition(
-                "",
-                r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+        new MockHttpClient(
+            new AssertRequest(
+                null,
+                new Condition(
+                    "",
+                    r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+                )
             )
         ).execute(new HttpGet("http://test.com"));
     }
@@ -95,12 +99,14 @@ public final class AssertRequestTestCase {
     public void failureMsg() throws Exception {
         final String msg = "Test message";
         try {
-            new AssertRequest(
-                null,
-                new Condition(
-                    msg,
-                    // @checkstyle LineLength (1 line)
-                    r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+            new MockHttpClient(
+                new AssertRequest(
+                    null,
+                    new Condition(
+                        msg,
+                        // @checkstyle LineLength (1 line)
+                        r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+                    )
                 )
             ).execute(new HttpGet("http://test.com"));
         } catch (final AssertionError error) {

--- a/src/test/java/com/amihaiemil/zold/mock/MockHttpClientTestCase.java
+++ b/src/test/java/com/amihaiemil/zold/mock/MockHttpClientTestCase.java
@@ -83,7 +83,9 @@ public final class MockHttpClientTestCase {
                 null,
                 new Condition(
                     "",
-                    r -> "http://some.test.com".equals(r.getRequestLine().getUri())
+                    r -> "http://some.test.com".equals(
+                        r.getRequestLine().getUri()
+                    )
                 )
             )
         ).execute(new HttpGet("http://test.com"));


### PR DESCRIPTION
For #26 
* renamed AssertRequest to MockHttpClient
* added support for asserting more consecutive requests (until now we could only assert one request).