### PR TITLE
#25: a test case for the PayloadOf provided.

### DIFF
--- a/src/main/java/com/amihaiemil/zold/PayloadOf.java
+++ b/src/main/java/com/amihaiemil/zold/PayloadOf.java
@@ -39,7 +39,6 @@ import java.io.IOException;
  * @author George Aristy (george.aristy@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #25:30min Add tests for PayloadOf.
  */
 final class PayloadOf extends JsonResource {
     /**

--- a/src/test/java/com/amihaiemil/zold/PayloadOfTestCase.java
+++ b/src/test/java/com/amihaiemil/zold/PayloadOfTestCase.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2019, Mihai Emil Andronache
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1)Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2)Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3)Neither the name of zold-java-client nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.amihaiemil.zold;
+
+import com.amihaiemil.zold.mock.Response;
+import org.apache.hc.core5.http.HttpStatus;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import javax.json.Json;
+
+/**
+ * Unit tests for {@link PayloadOf}.
+ */
+public class PayloadOfTestCase {
+
+    /**
+     * Checks whether the {@link PayloadOf} is instantiated.
+     */
+    @Test
+    public void instantiates() {
+        MatcherAssert.assertThat(
+            new PayloadOf(
+                new Response(
+                    HttpStatus.SC_OK,
+                    Json.createObjectBuilder()
+                        .add("key", "value")
+                        .build().toString()
+                )
+            ),
+            Matchers.instanceOf(PayloadOf.class)
+        );
+    }
+}

--- a/src/test/java/com/amihaiemil/zold/mock/Response.java
+++ b/src/test/java/com/amihaiemil/zold/mock/Response.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ProtocolVersion;
@@ -54,7 +55,7 @@ import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
  * @version $Id$
  * @since 0.0.1
  */
-public final class Response implements HttpResponse {
+public final class Response implements ClassicHttpResponse {
 
     /**
      * Its backbone, holding what we need.
@@ -211,6 +212,21 @@ public final class Response implements HttpResponse {
     @Override
     public Iterator<Header> headerIterator(final String name) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public HttpEntity getEntity() {
+        return this.backbone.getEntity();
+    }
+
+    @Override
+    public void setEntity(final HttpEntity httpEntity) {
+        this.backbone.setEntity(httpEntity);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.backbone.close();
     }
 
     /**


### PR DESCRIPTION
This is a solution for issue #25.

- A test case covering object instantiation has been created.
- The mock Response class has been adjusted to implement ClassicHttpResponse.
- I don't see the reason in implementing unit tests for the unused code: com.amihaiemil.zold.PayloadOf#PayloadOf(org.apache.hc.core5.http.ClassicHttpRequest). So, the puzzle has been removed.